### PR TITLE
Create User in Database on Signup

### DIFF
--- a/app/src/main/java/com/example/hubspot/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/hubspot/auth/AuthRepository.kt
@@ -45,7 +45,11 @@ class AuthRepository {
                 // Successfully signed in, check if email is verified (and thus acc activated)
                 val currentUser = auth.currentUser
                 if (currentUser != null && currentUser.isEmailVerified) {
-                    val user = User(currentUser.uid, currentUser.email, currentUser.email)
+                    val user = User(
+                        currentUser.uid,
+                        currentUser.email,
+                        getDisplayNameFromEmail(currentUser.email)
+                    )
                     createDatabaseUserIfNotExists(user, authResult)
                 } else {
                     authResult.value =
@@ -55,6 +59,19 @@ class AuthRepository {
                 // Failed to sign in, tell the user why
                 handleAuthError(task, authResult)
             }
+        }
+    }
+
+    private fun getDisplayNameFromEmail(email: String?): String? {
+        if (email != null) {
+            val getBeforeAtSign = email.split("@")
+            if (getBeforeAtSign.isNotEmpty()) {
+                return getBeforeAtSign[0]
+            } else {
+                return null
+            }
+        } else {
+            return null
         }
     }
 
@@ -104,7 +121,7 @@ class AuthRepository {
     private fun createUserInDatabase(user: User, authResult: MutableLiveData<AuthResult>) {
         // Update display name to email default first
         val updateDisplayName = UserProfileChangeRequest.Builder()
-            .setDisplayName(user.email).build()
+            .setDisplayName(user.displayName).build()
         val firebaseUser = Firebase.auth.currentUser
         firebaseUser!!.updateProfile(updateDisplayName).addOnCompleteListener { updateTask ->
             if (updateTask.isSuccessful) {

--- a/app/src/main/java/com/example/hubspot/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/hubspot/auth/AuthRepository.kt
@@ -5,7 +5,12 @@ import com.example.hubspot.models.User
 import com.google.android.gms.tasks.Task
 import com.google.firebase.FirebaseTooManyRequestsException
 import com.google.firebase.auth.FirebaseAuthException
+import com.google.firebase.auth.UserProfileChangeRequest
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.database.ValueEventListener
 import com.google.firebase.ktx.Firebase
 
 /** Layer of abstraction between the AuthViewModel and Firebase Auth.
@@ -17,7 +22,7 @@ class AuthRepository {
         fun getCurrentUser(): User? {
             val firebaseUser = Firebase.auth.currentUser
             if (firebaseUser != null && firebaseUser.isEmailVerified) {
-                return User(firebaseUser.uid, firebaseUser.email!!)
+                return User(firebaseUser.uid, firebaseUser.email, firebaseUser.displayName)
             }
             return null
         }
@@ -40,10 +45,8 @@ class AuthRepository {
                 // Successfully signed in, check if email is verified (and thus acc activated)
                 val currentUser = auth.currentUser
                 if (currentUser != null && currentUser.isEmailVerified) {
-                    authResult.value = AuthResult(
-                        AuthResultCode.SUCCESS,
-                        User(currentUser.uid, currentUser.email!!)
-                    )
+                    val user = User(currentUser.uid, currentUser.email, currentUser.email)
+                    createDatabaseUserIfNotExists(user, authResult)
                 } else {
                     authResult.value =
                         AuthResult(AuthResultCode.ACCOUNT_NOT_ACTIVATED, null)
@@ -61,7 +64,69 @@ class AuthRepository {
         SUCCESS, EMAIL_PASSWORD_EMPTY, ACCOUNT_NOT_ACTIVATED, INVALID_EMAIL,
         UNKNOWN_ERROR, EMAIL_ALREADY_USED, WEAK_PASSWORD, WRONG_PASSWORD,
         USER_NOT_FOUND, NO_LOGIN_OR_SIGNUP, ACCOUNT_ALREADY_ACTIVATED,
-        FAILED_TO_SEND_ACTIVATION_EMAIL, TOO_MANY_REQUESTS_AT_ONCE
+        FAILED_TO_SEND_ACTIVATION_EMAIL, TOO_MANY_REQUESTS_AT_ONCE,
+        FAILED_TO_READ_DATABASE, FAILED_TO_WRITE_USER_TO_DATABASE, FAILED_TO_SET_AUTH_DISPLAY_NAME
+    }
+
+    private fun createDatabaseUserIfNotExists(user: User, authResult: MutableLiveData<AuthResult>) {
+        val database = FirebaseDatabase.getInstance()
+        val usersRef = database.getReference("Users")
+
+        val getUserByIdQuery = usersRef.orderByChild("id").equalTo(user.id)
+        val getUserListener = object : ValueEventListener {
+            override fun onDataChange(dataSnapshot: DataSnapshot) {
+                // Get User object by id (should only be one in list or null)
+                val foundUsers = dataSnapshot.value
+                if (foundUsers == null || (foundUsers as HashMap<*, *>).isEmpty()) {
+                    // no user in db exists, so create one
+                    createUserInDatabase(user, authResult)
+                } else {
+                    // user already exists, just log in already
+                    authResult.value = AuthResult(
+                        AuthResultCode.SUCCESS,
+                        user
+                    )
+                }
+
+                // Prevent this listener from firing even after logging in the app
+                getUserByIdQuery.removeEventListener(this)
+            }
+
+            override fun onCancelled(databaseError: DatabaseError) {
+                // Getting User failed, return error to view model to update UI
+                authResult.value = AuthResult(AuthResultCode.FAILED_TO_READ_DATABASE, null)
+            }
+        }
+
+        getUserByIdQuery.addValueEventListener(getUserListener)
+    }
+
+    private fun createUserInDatabase(user: User, authResult: MutableLiveData<AuthResult>) {
+        // Update display name to email default first
+        val updateDisplayName = UserProfileChangeRequest.Builder()
+            .setDisplayName(user.email).build()
+        val firebaseUser = Firebase.auth.currentUser
+        firebaseUser!!.updateProfile(updateDisplayName).addOnCompleteListener { updateTask ->
+            if (updateTask.isSuccessful) {
+                // Then, create user in database
+                val database = FirebaseDatabase.getInstance()
+                val usersRef = database.getReference("Users")
+
+                usersRef.child(user.id!!).setValue(user).addOnCompleteListener { createUserTask ->
+                    if (createUserTask.isSuccessful) {
+                        authResult.value = AuthResult(
+                            AuthResultCode.SUCCESS,
+                            user
+                        )
+                    } else {
+                        authResult.value =
+                            AuthResult(AuthResultCode.FAILED_TO_WRITE_USER_TO_DATABASE, null)
+                    }
+                }
+            } else {
+                authResult.value = AuthResult(AuthResultCode.FAILED_TO_SET_AUTH_DISPLAY_NAME, null)
+            }
+        }
     }
 
     fun handleAuthError(
@@ -148,7 +213,10 @@ class AuthRepository {
                 if (task.isSuccessful) {
                     // activation email successfully sent
                     authResult.value =
-                        AuthResult(AuthResultCode.SUCCESS, User(user.uid, user.email!!))
+                        AuthResult(
+                            AuthResultCode.SUCCESS,
+                            User(user.uid, user.email, user.displayName)
+                        )
                 } else {
                     // Failed to send activation email
                     if (task.exception is FirebaseTooManyRequestsException) {

--- a/app/src/main/java/com/example/hubspot/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/hubspot/login/LoginActivity.kt
@@ -94,6 +94,9 @@ class LoginActivity : AppCompatActivity() {
             ACCOUNT_NOT_ACTIVATED -> displayAccountNotActivatedError()
             TOO_MANY_REQUESTS_AT_ONCE -> displayTooManyRequestsAtOnceError()
             NO_LOGIN_OR_SIGNUP -> displayNoPreviousLogInOrSignUpError()
+            FAILED_TO_READ_DATABASE -> displayFailedToReadFromDatabaseError()
+            FAILED_TO_WRITE_USER_TO_DATABASE -> displayFailedToWriteUserToDatabaseError()
+            FAILED_TO_SET_AUTH_DISPLAY_NAME -> displayFailedToSetUserAuthDisplayNameError()
             else -> displayCatchAllAuthError()
         }
     }
@@ -176,6 +179,21 @@ class LoginActivity : AppCompatActivity() {
 
     private fun displayInvalidEmailError() {
         val errorMessage = resources.getString(R.string.login_toast_invalid_email)
+        showToast(errorMessage)
+    }
+
+    private fun displayFailedToReadFromDatabaseError() {
+        val errorMessage = resources.getString(R.string.login_toast_fail_read_database)
+        showToast(errorMessage)
+    }
+
+    private fun displayFailedToSetUserAuthDisplayNameError() {
+        val errorMessage = resources.getString(R.string.login_toast_set_user_auth_displayname_fail)
+        showToast(errorMessage)
+    }
+
+    private fun displayFailedToWriteUserToDatabaseError() {
+        val errorMessage = resources.getString(R.string.login_toast_create_user_in_database_fail)
         showToast(errorMessage)
     }
 

--- a/app/src/main/java/com/example/hubspot/models/User.kt
+++ b/app/src/main/java/com/example/hubspot/models/User.kt
@@ -1,5 +1,13 @@
 package com.example.hubspot.models
 
-class User (var id: String, var email: String) {
-    var displayName: String = email
+import com.google.firebase.database.IgnoreExtraProperties
+
+@IgnoreExtraProperties
+data class User(
+    val id: String? = null,
+    val email: String? = null,
+    val displayName: String? = null
+) {
+    // Null default values create a no-argument default constructor, which is needed
+    // for deserialization from a DataSnapshot.
 }

--- a/app/src/main/res/values/activity_login_strings.xml
+++ b/app/src/main/res/values/activity_login_strings.xml
@@ -25,4 +25,7 @@
     <string name="login_toast_try_logging_in_first">Please login or try signing up an account before resending an activation email.</string>
     <string name="login_toast_user_not_found">This account does not exist. Please check your credentials and try again or sign up for a new account.</string>
     <string name="login_toast_too_many_requests_at_once">Too many requests made at once. Please wait and try again later.</string>
+    <string name="login_toast_fail_read_database">Failed to read from database. Please try again later.</string>
+    <string name="login_toast_set_user_auth_displayname_fail">Failed to set Firebase auth display name. Please try again later.</string>
+    <string name="login_toast_create_user_in_database_fail">Failed to create user in database, please try again later.</string>
 </resources>


### PR DESCRIPTION
When users first log in for a newly created account, a new user record will be simultaneously created in the Firebase Realtime Database. Additionally, the default display name for a user will be set to the first part of the user's email, which can be changed further in the profile page to their liking.

**User record in database after first login:**
![image](https://user-images.githubusercontent.com/62604641/181838741-0d8c77a9-0504-4377-b048-02a71ec3be00.png)